### PR TITLE
feat: support replaceHostRegExpMap config

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,6 +209,11 @@
           "https://raw.github.com/imagemin/jpegoptim-bin"
         ],
         "host": "https://npm.taobao.org/mirrors/jpegoptim-bin"
+      },
+      "vscode": {
+        "replaceHostRegExpMap": {
+          "https://raw\\.githubusercontent\\.com/": "https://raw.github.cnpmjs.org/"
+        }
       }
     }
   }


### PR DESCRIPTION
use RegExp to replace all mirror hosts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/binary-mirror-config/7)
<!-- Reviewable:end -->
