### PR TITLE
feat: add sharp libvips binary host to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "PUPPETEER_DOWNLOAD_HOST": "https://cdn.npm.taobao.org/dist",
         "SENTRYCLI_CDNURL": "https://cdn.npm.taobao.org/dist/sentry-cli",
         "npm_config_sharp_binary_host": "https://cdn.npm.taobao.org/dist/sharp",
+        "npm_config_sharp_libvips_binary_host":"https://npm.taobao.org/mirrors/sharp-libvips",
         "npm_config_robotjs_binary_host": "https://cdn.npm.taobao.org/dist/robotjs"
       },
       "@ali/s2": {


### PR DESCRIPTION
Alibaba provide a mirror site based in China containing binaries for both sharp and libvips.

add it to cnpm so we can install this library quickly!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/binary-mirror-config/13)
<!-- Reviewable:end -->
