### PR TITLE
fix: delete canvas mirror

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,9 +169,6 @@
       "canvas-prebuilt": {
         "host": "https://cdn.npm.taobao.org/dist/canvas-prebuilt"
       },
-      "canvas": {
-        "host": "https://cdn.npm.taobao.org/dist/node-canvas-prebuilt"
-      },
       "flow-bin": {
         "replaceHost": "https://github.com/facebook/flow/releases/download/v",
         "host": "https://cdn.npm.taobao.org/dist/flow/v"


### PR DESCRIPTION
https://github.com/node-gfx/node-canvas-prebuilt

> NOTE: the canvas-prebuilt package is deprecated. As of version 2, canvas itself bundles prebuilt versions from this repo. Install by running

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/binary-mirror-config/14)
<!-- Reviewable:end -->
