### PR TITLE
feat: canvas 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
         "host": "https://cdn.npmmirror.com/binaries/nodejieba"
       },
       "canvas": {
-        "host": "https://cdn.npmmirror.com/binaries/canvas"
+        "host": "https://cdn.npmmirror.com/binaries/canvas",
+        "remote_path": "v{version}"
       },
       "skia-canvas": {
         "host": "https://cdn.npmmirror.com/binaries/skia-canvas"

--- a/test/fixtures/canvas/package.json
+++ b/test/fixtures/canvas/package.json
@@ -4,6 +4,7 @@
     "install": "node-pre-gyp install --fallback-to-build --update-binary"
   },
   "binary": {
-    "host": "https://cdn.npmmirror.com/binaries/canvas"
+    "host": "https://cdn.npmmirror.com/binaries/canvas",
+    "remote_path": "v{version}"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -191,6 +191,7 @@ describe('test/index.test.js', () => {
         },
         binary: {
           host: 'https://cdn.npmmirror.com/binaries/canvas',
+          remote_path: 'v{version}',
         },
       });
     });


### PR DESCRIPTION
> canvas 3.x 开始修改了 binary 配置，不再设置 remotePath 和 host 配置，导致原匹配规则失效

https://npmmirror.com/package/canvas/files?version=3.1.0#L66-L67

https://npmmirror.com/package/canvas/files?version=2.11.2#L41-L42

新增 remotePath 兼容 3.x 配置，和 2.x 保持一致

![image](https://github.com/user-attachments/assets/396f07b8-6300-4af7-b5a1-eabfc33e6598)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced configuration for binary assets by adding a versioned remote path. This update streamlines asset retrieval by associating binaries with specific version identifiers, ensuring a more structured and consistent approach to version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->